### PR TITLE
Fix typegen npm script to run on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "rollup -c",
     "prepare": "npm run build",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false --strict --jsx react",
-    "typegen": "tsc && mv dist/src/* dist && rm -rf dist/src || true",
+    "typegen": "tsc",
     "test": "echo tests are missing"
   },
   "husky": {


### PR DESCRIPTION
The `typegen` npm script fails in most Windows environments. I can see that the script expects files to be created in `dist/src/`. The script tries to move those files up one directory, to `dist/` - but after building the project without modifying directories on both Unix and Windows environments, no `dist/src/` directory is created. All files are already built into `dist/`, so I believe we can simplify the `typegen` script. Let me know if this is still necessary for some reason.