### PR TITLE
add event bridge

### DIFF
--- a/examples/src/demos/ConvexPolyhydron.js
+++ b/examples/src/demos/ConvexPolyhydron.js
@@ -7,7 +7,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
 function Diamond(props) {
   const { nodes } = useLoader(GLTFLoader, '/diamond.glb')
   const geo = useMemo(() => new THREE.Geometry().fromBufferGeometry(nodes.Cylinder.geometry), [])
-  const [ref] = useConvexPolyhedron(() => ({ mass: 100, ...props, args: geo, onCollide: e => console.log(e.contact) }))
+  const [ref] = useConvexPolyhedron(() => ({ mass: 100, ...props, args: geo, onCollide: e => console.log(e) }))
   return (
     <mesh castShadow ref={ref} geometry={nodes.Cylinder.geometry} dispose={null}>
       <meshNormalMaterial attach="material" />

--- a/examples/src/demos/ConvexPolyhydron.js
+++ b/examples/src/demos/ConvexPolyhydron.js
@@ -7,7 +7,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
 function Diamond(props) {
   const { nodes } = useLoader(GLTFLoader, '/diamond.glb')
   const geo = useMemo(() => new THREE.Geometry().fromBufferGeometry(nodes.Cylinder.geometry), [])
-  const [ref] = useConvexPolyhedron(() => ({ mass: 100, ...props, args: geo }))
+  const [ref] = useConvexPolyhedron(() => ({ mass: 100, ...props, args: geo, onCollide: e => console.log(e.contact) }))
   return (
     <mesh castShadow ref={ref} geometry={nodes.Cylinder.geometry} dispose={null}>
       <meshNormalMaterial attach="material" />

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -20,6 +20,7 @@ type BodyProps = {
   collisionFilterMask?: number
   fixedRotation?: boolean
   type?: 'Dynamic' | 'Static' | 'Kinematic'
+  onCollide?: () => void
 }
 
 type ShapeType =
@@ -84,7 +85,7 @@ function apply(object: THREE.Object3D, index: number, buffers: Buffers) {
 
 function useBody(type: ShapeType, fn: BodyFn, argFn: ArgFn, deps: any[] = []): Api {
   const ref = useRef<THREE.Object3D>()
-  const { worker, bodies, buffers } = useContext(context)
+  const { worker, bodies, buffers, events } = useContext(context)
   useLayoutEffect(() => {
     if (ref.current) {
       const object = ref.current
@@ -105,9 +106,19 @@ function useBody(type: ShapeType, fn: BodyFn, argFn: ArgFn, deps: any[] = []): A
         })
       } else props = [prepare(object, fn(0), argFn)]
 
+      props.forEach((props, index) => {
+        if (props.onCollide) {
+          events[uuid[index]] = props.onCollide
+          ;(props as any).onCollide = true
+        }
+      })
+
       // Register on mount, unregister on unmount
       currentWorker.postMessage({ op: 'addBodies', type, uuid, props })
-      return () => currentWorker.postMessage({ op: 'removeBodies', uuid })
+      return () => {
+        props.forEach((props, index) => props.onCollide && delete events[uuid[index]])
+        currentWorker.postMessage({ op: 'removeBodies', uuid })
+      }
     }
   }, [ref.current, ...deps]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,10 +2,11 @@ import React, { Suspense, createContext, lazy } from 'react'
 import { ProviderProps } from './Provider'
 export * from './hooks'
 
-type ProviderContext = {
+export type ProviderContext = {
   worker: Worker
   bodies: React.MutableRefObject<{ [uuid: string]: number }>
   buffers: { positions: Float32Array; quaternions: Float32Array }
+  events: { [uuid: string]: () => void }
 }
 
 const context = createContext<ProviderContext>({} as ProviderContext)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,11 +2,27 @@ import React, { Suspense, createContext, lazy } from 'react'
 import { ProviderProps } from './Provider'
 export * from './hooks'
 
+export type Refs = { [uuid: string]: THREE.Object3D }
+export type Event = {
+  op: string
+  type: string
+  body: THREE.Object3D
+  target: THREE.Object3D
+  contact: {
+    ni: number[]
+    ri: number[]
+    rj: number[]
+    impactVelocity: number
+  }
+}
+export type Events = { [uuid: string]: (e: Event) => void }
+
 export type ProviderContext = {
   worker: Worker
   bodies: React.MutableRefObject<{ [uuid: string]: number }>
   buffers: { positions: Float32Array; quaternions: Float32Array }
-  events: { [uuid: string]: () => void }
+  refs: Refs
+  events: Events
 }
 
 const context = createContext<ProviderContext>({} as ProviderContext)

--- a/src/worker.js
+++ b/src/worker.js
@@ -128,9 +128,9 @@ self.onmessage = e => {
               body: body.uuid,
               target: target.uuid,
               contact: {
-                ni,
-                ri,
-                rj,
+                ni: ni.toArray(),
+                ri: ri.toArray(),
+                rj: rj.toArray(),
                 impactVelocity: contact.getImpactVelocityAlongNormal(),
               },
             })

--- a/src/worker.js
+++ b/src/worker.js
@@ -75,6 +75,7 @@ self.onmessage = e => {
           rotation = [0, 0, 0],
           scale = [1, 1, 1],
           type: bodyType,
+          onCollide,
           ...extra
         } = props[i]
 
@@ -117,14 +118,29 @@ self.onmessage = e => {
         body.position.set(position[0], position[1], position[2])
         body.quaternion.setFromEuler(rotation[0], rotation[1], rotation[2])
         world.addBody(body)
-        //body.addEventListener('collide', e => console.log('collide', e))
+
+        if (onCollide)
+          body.addEventListener('collide', ({ type, contact, target }) => {
+            const { ni, ri, rj } = contact
+            self.postMessage({
+              op: 'event',
+              type,
+              body: body.uuid,
+              target: target.uuid,
+              contact: {
+                ni,
+                ri,
+                rj,
+                impactVelocity: contact.getImpactVelocityAlongNormal(),
+              },
+            })
+          })
       }
       syncBodies()
       break
     }
     case 'removeBodies': {
       for (let i = 0; i < uuid.length; i++) world.removeBody(bodies[uuid[i]])
-
       syncBodies()
       break
     }


### PR DESCRIPTION
working example: examples/demos/ConvexPolyhydron

```jsx
const [ref] = useConvexPolyhedron(() =>
  ({ mass: 100, ...props, args: geo, onCollide: e => console.log(e) }))
  return (
    <mesh ref={ref}>
```

prints out:

```
{
  op: "event",
  type: "collide",
  contact: {
    impactVelocity: 9.12533490024342,
    ni: [0, 1, 2.220446049250313e-16],
    ri: [0.0853278344528522, 2.7755575615628914e-17, -0.09384641598651859],
    rj: [0.0853278344528522, -0.8495775410906926, -0.09384641598651862],
  },
  body: THREE.Object3D,
  target: THREE.Object3D
}
```