### PR TITLE
Add collisionGroups to body collide event

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -133,6 +133,12 @@ self.onmessage = e => {
                 rj: rj.toArray(),
                 impactVelocity: contact.getImpactVelocityAlongNormal(),
               },
+              collisionGroups: {
+                bodyFilterGroup: body.collisionFilterGroup,
+                bodyFilterMask: body.collisionFilterMask,
+                targetFilterGroup: target.collisionFilterGroup,
+                targetFilterMask: target.collisionFilterMask,
+              },
             })
           })
       }


### PR DESCRIPTION
Addresses #19 by adding `collisionFilterGroup` and `collisionFilterMask` for both body and target in the "collide" event.

```js
const GROUP1 = 1;
const GROUP2 = 2;
const GROUP3 = 4;

const [ref1] = usePlane(() =>
  ({ ...props, collisionFilterGroup: GROUP1, collisionFilterMask: GROUP2 | GROUP3, onCollide: e => console.log(e) }))

const [ref2] = useSphere(() => {
  const collisionGroup = Math.round(Math.random()) ? GROUP2 : GROUP3;
  return { ...props, collisionFilterGroup: collisionGroup, collisionFilterMask: GROUP1 | collisionGroup }
})
```

When a sphere collides with the plane, onCollide prints:

```js
{
  op: "event",
  type: "collide",
  body: THREE.Object3D,
  target: THREE.Object3D,
  contact: {
    impactVelocity: 9.12533490024342,
    ni: [0, 1, 2.220446049250313e-16],
    ri: [0.0853278344528522, 2.7755575615628914e-17, -0.09384641598651859],
    rj: [0.0853278344528522, -0.8495775410906926, -0.09384641598651862],
  },
  collisionGroups: {
    bodyFilterGroup: 1,
    bodyFilterMask: 6,
    targetFilterGroup: 4,
    targetFilterMask: 7,
  },
}
```