### PR TITLE
Newapi

### DIFF
--- a/examples/src/demos/Constraints.js
+++ b/examples/src/demos/Constraints.js
@@ -14,8 +14,8 @@ const Box = React.forwardRef((props, ref) => {
 })
 
 const Ball = React.forwardRef((props, ref) => {
-  const [ball, { setPosition }] = useSphere(() => ({ type: 'Static', mass: 1, args: 0.5, ...props }))
-  useFrame(e => setPosition((e.mouse.x * e.viewport.width) / 2, (e.mouse.y * e.viewport.height) / 2, 0))
+  const [ball, { position }] = useSphere(() => ({ type: 'Static', mass: 1, args: 0.5, ...props }))
+  useFrame(e => position.set((e.mouse.x * e.viewport.width) / 2, (e.mouse.y * e.viewport.height) / 2, 0))
   return (
     <mesh ref={mergeRefs([ball, ref])}>
       <sphereBufferGeometry attach="geometry" args={[0.5, 64, 64]} />

--- a/examples/src/demos/CubeHeap.js
+++ b/examples/src/demos/CubeHeap.js
@@ -15,7 +15,7 @@ function Plane(props) {
 }
 
 function Cubes({ number }) {
-  const [ref, api] = useBox(() => ({
+  const [ref, { at }] = useBox(() => ({
     mass: 1,
     args: [0.05, 0.05, 0.05],
     position: [Math.random() - 0.5, Math.random() * 2, Math.random() - 0.5],
@@ -32,10 +32,7 @@ function Cubes({ number }) {
     return array
   }, [number])
 
-  useFrame(() => {
-    const instancedApi = api.at(Math.floor(Math.random() * number))
-    instancedApi.position.set(0, Math.random() * 2, 0)
-  })
+  useFrame(() => at(Math.floor(Math.random() * number)).position.set(0, Math.random() * 2, 0))
 
   return (
     <instancedMesh receiveShadow castShadow ref={ref} args={[null, null, number]}>

--- a/examples/src/demos/CubeHeap.js
+++ b/examples/src/demos/CubeHeap.js
@@ -32,7 +32,10 @@ function Cubes({ number }) {
     return array
   }, [number])
 
-  useFrame(() => api.setPositionAt(Math.floor(Math.random() * number), 0, Math.random() * 2, 0))
+  useFrame(() => {
+    //const instancedApi = api.at(Math.floor(Math.random() * number))
+    //instancedApi.position.set(0, Math.random() * 2, 0)
+  })
 
   return (
     <instancedMesh receiveShadow castShadow ref={ref} args={[null, null, number]}>

--- a/examples/src/demos/CubeHeap.js
+++ b/examples/src/demos/CubeHeap.js
@@ -33,8 +33,8 @@ function Cubes({ number }) {
   }, [number])
 
   useFrame(() => {
-    //const instancedApi = api.at(Math.floor(Math.random() * number))
-    //instancedApi.position.set(0, Math.random() * 2, 0)
+    const instancedApi = api.at(Math.floor(Math.random() * number))
+    instancedApi.position.set(0, Math.random() * 2, 0)
   })
 
   return (

--- a/examples/src/demos/KinematicCube.js
+++ b/examples/src/demos/KinematicCube.js
@@ -18,8 +18,8 @@ function Box() {
   const [ref, api] = useBox(() => ({ type: 'Kinematic', mass: 1, args: [2, 2, 2] }))
   useFrame(state => {
     const t = state.clock.getElapsedTime()
-    api.setPosition(Math.sin(t * 2) * 5, Math.cos(t * 2) * 5, 3)
-    api.setRotation(Math.sin(t * 6), Math.cos(t * 6), 0)
+    api.position.set(Math.sin(t * 2) * 5, Math.cos(t * 2) * 5, 3)
+    api.rotation.set(Math.sin(t * 6), Math.cos(t * 6), 0)
   })
   return (
     <mesh ref={ref} castShadow receiveShadow>

--- a/examples/src/demos/Pingpong/index.js
+++ b/examples/src/demos/Pingpong/index.js
@@ -45,8 +45,8 @@ function Paddle() {
   useFrame(state => {
     values.current[0] = lerp(values.current[0], (state.mouse.x * Math.PI) / 5, 0.2)
     values.current[1] = lerp(values.current[1], (state.mouse.x * Math.PI) / 5, 0.2)
-    api.setPosition(state.mouse.x * 10, state.mouse.y * 5, 0)
-    api.setRotation(0, 0, values.current[1])
+    api.position.set(state.mouse.x * 10, state.mouse.y * 5, 0)
+    api.rotation.set(0, 0, values.current[1])
     model.current.rotation.x = lerp(model.current.rotation.x, welcome ? Math.PI / 2 : 0, 0.2)
     model.current.rotation.y = values.current[0]
   })

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "cannon-es": "^0.7.0",
+    "cannon-es": "^0.6.10",
     "husky": "^4.2.3",
     "lebab": "^3.1.0",
     "prettier": "^1.19.1",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -62,19 +62,23 @@ type TrimeshFn = (index: number) => TrimeshProps
 type ConvexPolyhedronFn = (index: number) => ConvexPolyhedronProps
 type ArgFn = (props: any) => any[]
 
-type Api = [
-  React.MutableRefObject<THREE.Object3D | undefined>,
-  {
-    /*setPosition: (x: number, y: number, z: number) => void
-    setRotation: (x: number, y: number, z: number) => void
-    setPositionAt: (index: number, x: number, y: number, z: number) => void
-    setRotationAt: (index: number, x: number, y: number, z: number) => void
-    applyForce: (force: [number, number, number], worldPoint: [number, number, number]) => void
-    applyImpulse: (impulse: [number, number, number], worldPoint: [number, number, number]) => void
-    applyLocalForce: (force: [number, number, number], localPoint: [number, number, number]) => void
-    applyLocalImpulse: (impulse: [number, number, number], localPoint: [number, number, number]) => void*/
-  }
-]
+type WorkerVec = {
+  set: (x: number, y: number, z: number) => void
+  copy: ({ x, y, z }: THREE.Vector3 | THREE.Euler) => void
+}
+
+type WorkerApi = AtomicProps & {
+  position: WorkerVec
+  rotation: WorkerVec
+  velocity: WorkerVec
+  angularVelocity: WorkerVec
+  applyForce: (force: number[], worldPoint: number[]) => void
+  applyImpulse: (impulse: number[], worldPoint: number[]) => void
+  applyLocalForce: (force: number[], localPoint: number[]) => void
+  applyLocalImpulse: (impulse: number[], localPoint: number[]) => void
+}
+
+type Api = [React.MutableRefObject<THREE.Object3D | undefined>, WorkerApi]
 
 const temp = new THREE.Object3D()
 
@@ -151,123 +155,71 @@ function useBody(type: ShapeType, fn: BodyFn, argFn: ArgFn, deps: any[] = []): A
     }
   })
 
-  const getUUID = (index?: number) =>
-    index !== undefined ? `${ref.current.uuid}/${index}` : ref.current.uuid
-  const captilaize = (name: string) => name.charAt(0).toUpperCase() + name.slice(1)
-  const post = (op: string, index: number | undefined, props: any) =>
-    ref.current && worker.postMessage({ op: `set${captilaize(op)}`, uuid: getUUID(index), props })
-  const makeVec = (op: string, index: number | undefined) => ({
-    set: (x: number, y: number, z: number) => post(op, index, [x, y, z]),
-    copy: ({ x, y, z }: THREE.Vector3 | THREE.Euler) => post(op, index, [x, y, z]),
-  })
-
-  type WorkerVec = {
-    set: (x: number, y: number, z: number) => void
-    copy: ({ x, y, z }: THREE.Vector3 | THREE.Euler) => void
-  }
-
-  type WorkerApi = AtomicProps & {
-    position: WorkerVec
-    rotation: WorkerVec
-    velocity: WorkerVec
-    angularVelocity: WorkerVec
-  }
-
-  function makeApi(index?: number): WorkerApi {
-    return {
-      position: makeVec('position', index),
-      rotation: makeVec('rotation', index),
-      velocity: makeVec('velocity', index),
-      angularVelocity: makeVec('angularVelocity', index),
-      set mass(value: number) {
-        post('mass', index, value)
-      },
-      set linearDamping(value: number) {
-        post('linearDamping', index, value)
-      },
-      set angularDamping(value: number) {
-        post('angularDamping', index, value)
-      },
-      set allowSleep(value: boolean) {
-        post('allowSleep', index, value)
-      },
-      set sleepSpeedLimit(value: number) {
-        post('sleepSpeedLimit', index, value)
-      },
-      set sleepTimeLimit(value: number) {
-        post('sleepTimeLimit', index, value)
-      },
-      set collisionFilterGroup(value: number) {
-        post('collisionFilterGroup', index, value)
-      },
-      set collisionFilterMask(value: number) {
-        post('collisionFilterMask', index, value)
-      },
-      set fixedRotation(value: boolean) {
-        post('fixedRotation', index, value)
-      },
-    }
-  }
-
   const api = useMemo(() => {
+    const getUUID = (index?: number) =>
+      index !== undefined ? `${ref.current.uuid}/${index}` : ref.current.uuid
+    const post = (op: string, index: number | undefined, props: any) =>
+      ref.current && worker.postMessage({ op, uuid: getUUID(index), props })
+    const makeVec = (op: string, index: number | undefined) => ({
+      set: (x: number, y: number, z: number) => post(op, index, [x, y, z]),
+      copy: ({ x, y, z }: THREE.Vector3 | THREE.Euler) => post(op, index, [x, y, z]),
+    })
+
+    function makeApi(index?: number): WorkerApi {
+      return {
+        // Vectors
+        position: makeVec('setPosition', index),
+        rotation: makeVec('setRotation', index),
+        velocity: makeVec('setVelocity', index),
+        angularVelocity: makeVec('setAngularVelocity', index),
+        // Setters
+        set mass(value: number) {
+          post('setMass', index, value)
+        },
+        set linearDamping(value: number) {
+          post('setLinearDamping', index, value)
+        },
+        set angularDamping(value: number) {
+          post('setAngularDamping', index, value)
+        },
+        set allowSleep(value: boolean) {
+          post('setAllowSleep', index, value)
+        },
+        set sleepSpeedLimit(value: number) {
+          post('setSleepSpeedLimit', index, value)
+        },
+        set sleepTimeLimit(value: number) {
+          post('setSleepTimeLimit', index, value)
+        },
+        set collisionFilterGroup(value: number) {
+          post('setCollisionFilterGroup', index, value)
+        },
+        set collisionFilterMask(value: number) {
+          post('setCollisionFilterMask', index, value)
+        },
+        set fixedRotation(value: boolean) {
+          post('setFixedRotation', index, value)
+        },
+        // Apply functions
+        applyForce(force: number[], worldPoint: number[]) {
+          post('applyForce', index, [force, worldPoint])
+        },
+        applyImpulse(impulse: number[], worldPoint: number[]) {
+          post('applyImpulse', index, [impulse, worldPoint])
+        },
+        applyLocalForce(force: number[], localPoint: number[]) {
+          post('applyLocalForce', index, [force, localPoint])
+        },
+        applyLocalImpulse(impulse: number[], localPoint: number[]) {
+          post('applyLocalImpulse', index, [impulse, localPoint])
+        },
+      }
+    }
+
     const cache: { [index: number]: WorkerApi } = {}
     return {
       ...makeApi(undefined),
       at: (index: number) => cache[index] || (cache[index] = makeApi(index)),
-      /*setPosition(x: number, y: number, z: number) {
-        if (ref.current) worker.postMessage({ op: 'setPosition', uuid: ref.current.uuid, props: [x, y, z] })
-      },
-      setRotation(x: number, y: number, z: number) {
-        if (ref.current) worker.postMessage({ op: 'setRotation', uuid: ref.current.uuid, props: [x, y, z] })
-      },
-      setPositionAt(index: number, x: number, y: number, z: number) {
-        if (ref.current)
-          worker.postMessage({
-            op: 'setPosition',
-            uuid: `${ref.current.uuid}/${index}`,
-            props: [x, y, z],
-          })
-      },
-      setRotationAt(index: number, x: number, y: number, z: number) {
-        if (ref.current)
-          worker.postMessage({
-            op: 'setRotation',
-            uuid: `${ref.current.uuid}/${index}`,
-            props: [x, y, z],
-          })
-      },
-      applyForce(force: [number, number, number], worldPoint: [number, number, number]) {
-        if (ref.current)
-          worker.postMessage({
-            op: 'applyForce',
-            uuid: ref.current.uuid,
-            props: [force, worldPoint],
-          })
-      },
-      applyImpulse(impulse: [number, number, number], worldPoint: [number, number, number]) {
-        if (ref.current)
-          worker.postMessage({
-            op: 'applyImpulse',
-            uuid: ref.current.uuid,
-            props: [impulse, worldPoint],
-          })
-      },
-      applyLocalForce(force: [number, number, number], localPoint: [number, number, number]) {
-        if (ref.current)
-          worker.postMessage({
-            op: 'applyLocalForce',
-            uuid: ref.current.uuid,
-            props: [force, localPoint],
-          })
-      },
-      applyLocalImpulse(impulse: [number, number, number], localPoint: [number, number, number]) {
-        if (ref.current)
-          worker.postMessage({
-            op: 'applyLocalImpulse',
-            uuid: ref.current.uuid,
-            props: [impulse, localPoint],
-          })
-      },*/
     }
   }, [])
   return [ref, api]
@@ -329,23 +281,23 @@ type ConstraintTypes = 'PointToPoint' | 'ConeTwist' | 'Distance' | 'Hinge' | 'Lo
 type ConstraintOptns = { maxForce?: number; collideConnected?: boolean; wakeUpBodies?: boolean }
 
 type PointToPointConstraintOpts = ConstraintOptns & {
-  pivotA: [number, number, number]
-  pivotB: [number, number, number]
+  pivotA: number[]
+  pivotB: number[]
 }
 
 type ConeTwistConstraintOpts = ConstraintOptns & {
-  pivotA?: [number, number, number]
-  axisA?: [number, number, number]
-  pivotB?: [number, number, number]
-  axisB?: [number, number, number]
+  pivotA?: number[]
+  axisA?: number[]
+  pivotB?: number[]
+  axisB?: number[]
 }
 type DistanceConstraintOpts = ConstraintOptns & { distance?: number }
 
 type HingeConstraintOpts = ConstraintOptns & {
-  pivotA?: [number, number, number]
-  axisA?: [number, number, number]
-  pivotB?: [number, number, number]
-  axisB?: [number, number, number]
+  pivotA?: number[]
+  axisA?: number[]
+  pivotB?: number[]
+  axisB?: number[]
 }
 
 type LockConstraintOpts = ConstraintOptns & {}

--- a/src/worker.js
+++ b/src/worker.js
@@ -165,30 +165,60 @@ self.onmessage = e => {
       syncBodies()
       break
     }
-    case 'setPosition': {
+    case 'setPosition':
       bodies[uuid].position.set(props[0], props[1], props[2])
       break
-    }
-    case 'setRotation': {
+    case 'setRotation':
       bodies[uuid].quaternion.setFromEuler(props[0], props[1], props[2], 'XYZ')
       break
-    }
-    case 'applyForce': {
+    case 'setVelocity':
+      bodies[uuid].velocity.set(props[0], props[1], props[2])
+      break
+    case 'setAngularVelocity':
+      bodies[uuid].angularVelocity.set(props[0], props[1], props[2])
+      break
+    case 'setMass':
+      bodies[uuid].mass = props
+      break
+    case 'setLinearDamping':
+      bodies[uuid].linearDamping = props
+      break
+    case 'setAngularDamping':
+      bodies[uuid].angularDamping = props
+      break
+    case 'setAllowSleep':
+      bodies[uuid].allowSleep = props
+      break
+    case 'setSleepSpeedLimit':
+      bodies[uuid].sleepSpeedLimit = props
+      break
+    case 'setSleepTimeLimit':
+      bodies[uuid].sleepTimeLimit = props
+      break
+    case 'setCollisionFilterGroup':
+      bodies[uuid].collisionFilterGroup = props
+      break
+    case 'setCollisionFilterMask':
+      bodies[uuid].collisionFilterMask = props
+      break
+    case 'setCollisionFilterMask':
+      bodies[uuid].collisionFilterMask = props
+      break
+    case 'setFixedRotation':
+      bodies[uuid].fixedRotation = props
+      break
+    case 'applyForce':
       bodies[uuid].applyForce(new Vec3(...props[0]), new Vec3(...props[1]))
       break
-    }
-    case 'applyImpulse': {
+    case 'applyImpulse':
       bodies[uuid].applyImpulse(new Vec3(...props[0]), new Vec3(...props[1]))
       break
-    }
-    case 'applyLocalForce': {
+    case 'applyLocalForce':
       bodies[uuid].applyLocalForce(new Vec3(...props[0]), new Vec3(...props[1]))
       break
-    }
-    case 'applyLocalImpulse': {
+    case 'applyLocalImpulse':
       bodies[uuid].applyLocalImpulse(new Vec3(...props[0]), new Vec3(...props[1]))
       break
-    }
     case 'addConstraint': {
       const [bodyA, bodyB, optns] = props
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -221,7 +221,6 @@ self.onmessage = e => {
       break
     case 'addConstraint': {
       const [bodyA, bodyB, optns] = props
-
       let { pivotA, pivotB, axisA, axisB, ...options } = optns
 
       // is there a better way to enforce defaults?
@@ -271,16 +270,13 @@ self.onmessage = e => {
           constraint = new Constraint(bodies[bodyA], bodies[bodyB], optns)
           break
       }
-
       constraint.uuid = uuid
-
       world.addConstraint(constraint)
       break
     }
-    case 'removeConstraint': {
+    case 'removeConstraint':
       world.removeConstraint(uuid)
       break
-    }
     case 'addSpring': {
       const [bodyA, bodyB, optns] = props
       let { worldAnchorA, worldAnchorB, localAnchorA, localAnchorB, restLength, stiffness, damping } = optns

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,10 +1043,10 @@ caniuse-lite@^1.0.30001030:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001031.tgz#76f1bdd39e19567b855302f65102d9a8aaad5930"
   integrity sha512-DpAP5a1NGRLgYfaNCaXIRyGARi+3tJA2quZXNNA1Du26VyVkqvy2tznNu5ANyN1Y5aX44QDotZSVSUSi2uMGjg==
 
-cannon-es@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/cannon-es/-/cannon-es-0.7.0.tgz#964d14333d3523bab38a1017508e957957295d44"
-  integrity sha512-7vMqQRlUc/9a16eMwg1mn43bRlocBIsiIv5ud9icbRXqUoSU+fIAacYXYVRQCw58zxlwbuVhUSaJMFV8rcic6w==
+cannon-es@^0.6.10:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/cannon-es/-/cannon-es-0.6.10.tgz#62f9032b949dbfac56fbcf955edd68aaf11d3589"
+  integrity sha512-f02v8Jkgo+FnBI+EIeHF6SEAsHRH5Dx3nnqj5VA29fMLbfDnDoC1JUQ8SbJq/WtB2TCwAATSoT8B6PaFtnPXBw==
 
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
https://github.com/react-spring/use-cannon/issues/31

@nevernotsean it seems to work.

@codynova the recent cannon-es broke something. you can test it in the master branch, the cubeheap demo is broken. i've reverted to 0.6.10 in this branch for now.

```jsx
// instanced
const [ref, instancedApi] = useXyz()
const api = instancedApi.at(100)
api.position.set(0, 10, 0)
api.fixedRotation = true
api.mass = 2
api.applyForce(...)

  // single
const [ref, api] = useXyz()
api.position.set(0, 10, 0)
// Support for vectors and eulers (for both single and instanced)
api.rotation.copy(new THREE.Euler(0, 0, 0)
api.fixedRotation = true
api.mass = 2
api.applyForce(...)
```

with this system we can generate the api mostly automatically, which shrinks bundle size:

```jsx
type WorkerApi = AtomicProps & {
  position: WorkerVec
  rotation: WorkerVec
  velocity: WorkerVec
  angularVelocity: WorkerVec
  applyForce: (force: number[], worldPoint: number[]) => void
  applyImpulse: (impulse: number[], worldPoint: number[]) => void
  applyLocalForce: (force: number[], localPoint: number[]) => void
  applyLocalImpulse: (impulse: number[], localPoint: number[]) => void
}

const api = useMemo(() => {
    const getUUID = (index?: number) =>
      index !== undefined ? `${ref.current.uuid}/${index}` : ref.current.uuid
    const post = (op: string, index: number | undefined, props: any) =>
      ref.current && worker.postMessage({ op, uuid: getUUID(index), props })
    const makeVec = (op: string, index: number | undefined) => ({
      set: (x: number, y: number, z: number) => post(op, index, [x, y, z]),
      copy: ({ x, y, z }: THREE.Vector3 | THREE.Euler) => post(op, index, [x, y, z]),
    })

    function makeApi(index?: number): WorkerApi {
      return {
        // Vectors
        position: makeVec('setPosition', index),
        rotation: makeVec('setRotation', index),
        velocity: makeVec('setVelocity', index),
        angularVelocity: makeVec('setAngularVelocity', index),
        // Setters
        set mass(value: number) {
          post('setMass', index, value)
        },
        set linearDamping(value: number) {
          post('setLinearDamping', index, value)
        },
        set angularDamping(value: number) {
          post('setAngularDamping', index, value)
        },
        set allowSleep(value: boolean) {
          post('setAllowSleep', index, value)
        },
        set sleepSpeedLimit(value: number) {
          post('setSleepSpeedLimit', index, value)
        },
        set sleepTimeLimit(value: number) {
          post('setSleepTimeLimit', index, value)
        },
        set collisionFilterGroup(value: number) {
          post('setCollisionFilterGroup', index, value)
        },
        set collisionFilterMask(value: number) {
          post('setCollisionFilterMask', index, value)
        },
        set fixedRotation(value: boolean) {
          post('setFixedRotation', index, value)
        },
        // Apply functions
        applyForce(force: number[], worldPoint: number[]) {
          post('applyForce', index, [force, worldPoint])
        },
        applyImpulse(impulse: number[], worldPoint: number[]) {
          post('applyImpulse', index, [impulse, worldPoint])
        },
        applyLocalForce(force: number[], localPoint: number[]) {
          post('applyLocalForce', index, [force, localPoint])
        },
        applyLocalImpulse(impulse: number[], localPoint: number[]) {
          post('applyLocalImpulse', index, [impulse, localPoint])
        },
      }
    }

    const cache: { [index: number]: WorkerApi } = {}
    return {
      ...makeApi(undefined),
      at: (index: number) => cache[index] || (cache[index] = makeApi(index)),
    }
  }, [])
  return [ref, api]
```