### PR TITLE
Expose Body's addShape function via api.addShapes

### DIFF
--- a/examples/src/demos/CompoundBody.js
+++ b/examples/src/demos/CompoundBody.js
@@ -1,0 +1,59 @@
+import React, { Suspense, useEffect } from 'react'
+import { Canvas } from 'react-three-fiber'
+import { Physics, usePlane, useBox } from 'use-cannon'
+
+function Plane(props) {
+  const [ref] = usePlane(() => ({ type: 'Static', ...props }))
+  return (
+    <group ref={ref}>
+      <mesh>
+        <planeBufferGeometry attach="geometry" args={[8, 8]} />
+        <meshBasicMaterial attach="material" color="#ffb385" />
+      </mesh>
+      <mesh receiveShadow>
+        <planeBufferGeometry attach="geometry" args={[8, 8]} />
+        <shadowMaterial attach="material" color="lightsalmon" />
+      </mesh>
+    </group>
+  )
+}
+
+function CompoundBody(props) {
+  const [ref, api] = useBox(() => ({ mass: 12, ...props, args: [0.5, 0.5, 0.5] }))
+  useEffect(() => void api.addShapes([{ type: 'Sphere', position: [1, 0, 0], args: [0.65] }]), [])
+  return (
+    <group ref={ref}>
+      <mesh castShadow dispose={null}>
+        <boxBufferGeometry attach="geometry" args={[1, 1, 1]} />
+        <meshNormalMaterial attach="material" />
+      </mesh>
+      <mesh castShadow position={[1, 0, 0]} dispose={null}>
+        <sphereBufferGeometry attach="geometry" args={[0.65, 16, 16]} />
+        <meshNormalMaterial attach="material" />
+      </mesh>
+    </group>
+  )
+}
+
+export default () => (
+  <Canvas shadowMap gl={{ alpha: false }} camera={{ position: [-2, 1, 7], fov: 50 }}>
+    <color attach="background" args={['#f6d186']} />
+    <hemisphereLight intensity={0.35} />
+    <spotLight
+      position={[5, 5, 5]}
+      angle={0.3}
+      penumbra={1}
+      intensity={2}
+      castShadow
+      shadow-mapSize-width={1028}
+      shadow-mapSize-height={1028}
+    />
+    <Suspense fallback={null}>
+      <Physics iterations={6}>
+        <Plane rotation={[-Math.PI / 2, 0, 0]} />
+        <CompoundBody position={[1.5, 5, 0.5]} rotation={[1.25, -1.25, 0]} />
+        <CompoundBody position={[2.5, 3, 0.25]} rotation={[1.25, -1.25, 0]} />
+      </Physics>
+    </Suspense>
+  </Canvas>
+)

--- a/examples/src/demos/index.js
+++ b/examples/src/demos/index.js
@@ -12,5 +12,15 @@ const Pingpong = { descr: '', tags: [], Component: lazy(() => import('./Pingpong
 const MondayMorning = { descr: '', tags: [], Component: lazy(() => import('./MondayMorning')), bright: false }
 const Constraints = { descr: '', tags: [], Component: lazy(() => import('./Constraints')), bright: false }
 const Chain = { descr: '', tags: [], Component: lazy(() => import('./Chain')), bright: false }
+const CompoundBody = { descr: '', tags: [], Component: lazy(() => import('./CompoundBody')), bright: false }
 
-export { MondayMorning, Pingpong, KinematicCube, CubeHeap, ConvexPolyhedron, Chain, Constraints }
+export {
+  MondayMorning,
+  Pingpong,
+  KinematicCube,
+  CubeHeap,
+  ConvexPolyhedron,
+  Chain,
+  Constraints,
+  CompoundBody,
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -73,6 +73,7 @@ type WorkerApi = AtomicProps & {
   rotation: WorkerVec
   velocity: WorkerVec
   angularVelocity: WorkerVec
+  addShapes: (shapes: { type: ShapeType; position: number[]; rotation?: number[]; args?: any[] }[]) => void
   applyForce: (force: number[], worldPoint: number[]) => void
   applyImpulse: (impulse: number[], worldPoint: number[]) => void
   applyLocalForce: (force: number[], localPoint: number[]) => void
@@ -239,6 +240,10 @@ function useBody(type: ShapeType, fn: BodyFn, argFn: ArgFn, deps: any[] = []): A
         set fixedRotation(value: boolean) {
           post('setFixedRotation', index, value)
         },
+        // Shape functions
+        addShapes(shapes: { type: ShapeType; position: number[]; rotation?: number[]; args?: any[] }[]) {
+          post('addShapes', index, shapes)
+        },
         // Apply functions
         applyForce(force: number[], worldPoint: number[]) {
           post('applyForce', index, [force, worldPoint])
@@ -268,25 +273,25 @@ export function usePlane(fn: PlaneFn, deps: any[] = []) {
   return useBody('Plane', fn, () => [], deps)
 }
 export function useBox(fn: BoxFn, deps: any[] = []) {
-  return useBody('Box', fn, args => args || [0.5, 0.5, 0.5], deps)
+  return useBody('Box', fn, (args) => args || [0.5, 0.5, 0.5], deps)
 }
 export function useCylinder(fn: CylinderFn, deps: any[] = []) {
-  return useBody('Cylinder', fn, args => args, deps)
+  return useBody('Cylinder', fn, (args) => args, deps)
 }
 export function useHeightfield(fn: HeightfieldFn, deps: any[] = []) {
-  return useBody('Heightfield', fn, args => args, deps)
+  return useBody('Heightfield', fn, (args) => args, deps)
 }
 export function useParticle(fn: ParticleFn, deps: any[] = []) {
   return useBody('Particle', fn, () => [], deps)
 }
 export function useSphere(fn: SphereFn, deps: any[] = []) {
-  return useBody('Sphere', fn, radius => [radius ?? 1], deps)
+  return useBody('Sphere', fn, (radius) => [radius ?? 1], deps)
 }
 export function useTrimesh(fn: TrimeshFn, deps: any[] = []) {
   return useBody(
     'Trimesh',
     fn,
-    args => {
+    (args) => {
       const vertices = args instanceof THREE.Geometry ? args.vertices : args[0]
       const indices = args instanceof THREE.Geometry ? args.faces : args[1]
       return [
@@ -301,10 +306,10 @@ export function useConvexPolyhedron(fn: ConvexPolyhedronFn, deps: any[] = []) {
   return useBody(
     'ConvexPolyhedron',
     fn,
-    args => {
+    (args) => {
       const vertices = args instanceof THREE.Geometry ? args.vertices : args[0]
       const faces = args instanceof THREE.Geometry ? args.faces : args[1]
-      const normals = args instanceof THREE.Geometry ? args.faces.map(f => f.normal) : args[2]
+      const normals = args instanceof THREE.Geometry ? args.faces.map((f) => f.normal) : args[2]
       return [
         vertices.map((v: any) => (v instanceof THREE.Vector3 ? [v.x, v.y, v.z] : v)),
         faces.map((f: any) => (f instanceof THREE.Face3 ? [f.a, f.b, f.c] : f)),

--- a/src/worker.js
+++ b/src/worker.js
@@ -19,6 +19,7 @@ import {
   LockConstraint,
   Constraint,
   Spring,
+  Quaternion,
 } from 'cannon-es'
 
 let bodies = {}
@@ -213,6 +214,15 @@ self.onmessage = (e) => {
       break
     case 'setFixedRotation':
       bodies[uuid].fixedRotation = props
+      break
+    case 'addShapes':
+      props.forEach(({ type, position, rotation, args }) =>
+        bodies[uuid].addShape(
+          createShape(type, args),
+          new Vec3(...position),
+          rotation ? new Quaternion(...rotation) : undefined
+        )
+      )
       break
     case 'applyForce':
       bodies[uuid].applyForce(new Vec3(...props[0]), new Vec3(...props[1]))


### PR DESCRIPTION
* Expose Body's addShape function via api.addShapes
* Create CompoundBody demo example

We will probably want a `useCompoundBody` hook next, and maybe a `Body.prototype.removeShape` function in `cannon-es`.

We might also want to add a `Body.prototype.recalculateCenterOfMass` function to `cannon-es`, but after trying the formula mentioned here, it didn't seem to be working as I'd expect:
https://github.com/react-spring/use-cannon/issues/29#issuecomment-602400659