### PR TITLE
proposal: fix accessing local ref by removing deps #53

### DIFF
--- a/examples/src/demos/Constraints.js
+++ b/examples/src/demos/Constraints.js
@@ -3,13 +3,15 @@ import { Canvas, useFrame } from 'react-three-fiber'
 import { Physics, useSphere, useBox, useSpring } from 'use-cannon'
 
 const Box = React.forwardRef((props, ref) => {
-  useBox(() => ({
-    ref,
-    mass: 1,
-    args: [0.5, 0.5, 0.5],
-    linearDamping: 0.7,
-    ...props,
-  }))
+  useBox(
+    () => ({
+      mass: 1,
+      args: [0.5, 0.5, 0.5],
+      linearDamping: 0.7,
+      ...props,
+    }),
+    ref
+  )
   return (
     <mesh ref={ref}>
       <boxBufferGeometry attach="geometry" args={[1, 1, 1]} />
@@ -19,8 +21,8 @@ const Box = React.forwardRef((props, ref) => {
 })
 
 const Ball = React.forwardRef((props, ref) => {
-  const [_, { position }] = useSphere(() => ({ ref, type: 'Kinetic', args: 0.5, ...props }))
-  useFrame(e => position.set((e.mouse.x * e.viewport.width) / 2, (e.mouse.y * e.viewport.height) / 2, 0))
+  const [_, { position }] = useSphere(() => ({ type: 'Kinetic', args: 0.5, ...props }), ref)
+  useFrame((e) => position.set((e.mouse.x * e.viewport.width) / 2, (e.mouse.y * e.viewport.height) / 2, 0))
   return (
     <mesh ref={ref}>
       <sphereBufferGeometry attach="geometry" args={[0.5, 64, 64]} />

--- a/examples/src/demos/ConvexPolyhedron.js
+++ b/examples/src/demos/ConvexPolyhedron.js
@@ -8,12 +8,12 @@ import { ConvexGeometry } from 'three/examples/jsm/geometries/ConvexGeometry'
 function Diamond(props) {
   const { nodes } = useLoader(GLTFLoader, '/diamond.glb')
   const geo = useMemo(() => {
-    let geo = new THREE.Geometry().fromBufferGeometry(nodes.Cylinder.geometry)
+    const g = new THREE.Geometry().fromBufferGeometry(nodes.Cylinder.geometry)
     // Merge duplicate vertices resulting from glTF export.
     // Cannon assumes contiguous, closed meshes to work
-    geo.mergeVertices()
+    g.mergeVertices()
     // Ensure loaded mesh is convex and create faces if necessary
-    return new ConvexGeometry(geo.vertices)
+    return new ConvexGeometry(g.vertices)
   }, [nodes])
 
   const [ref] = useConvexPolyhedron(() => ({
@@ -30,8 +30,11 @@ function Diamond(props) {
 
 // A cone is a convex shape by definition...
 function Cone(props) {
-  const geo = new THREE.ConeGeometry(0.7, 0.7, props.sides, 1)
-  geo.mergeVertices()
+  const geo = useMemo(() => {
+    const g = new THREE.ConeGeometry(0.7, 0.7, props.sides, 1)
+    g.mergeVertices()
+    return g
+  }, [])
   const [ref] = useConvexPolyhedron(() => ({ mass: 100, ...props, args: geo }))
   return (
     <mesh castShadow ref={ref} dispose={null}>
@@ -43,8 +46,11 @@ function Cone(props) {
 
 // ...And so is a cube!
 function Cube(props) {
-  const geo = new THREE.BoxGeometry(props.size, props.size, props.size)
-  geo.mergeVertices()
+  const geo = useMemo(() => {
+    const g = new THREE.BoxGeometry(props.size, props.size, props.size)
+    g.mergeVertices()
+    return g
+  }, [])
   const [ref] = useConvexPolyhedron(() => ({ mass: 100, ...props, args: geo }))
   return (
     <mesh castShadow ref={ref} dispose={null}>

--- a/examples/src/demos/MondayMorning/index.js
+++ b/examples/src/demos/MondayMorning/index.js
@@ -58,7 +58,7 @@ const BodyPart = ({ config, children, render, name, ...props }) => {
 function Ragdoll(props) {
   const mouth = useRef()
   const eyes = useRef()
-  const [ref, api] = useSphere(() => ({ ref: cursor, type: 'Static', args: [0.5], position: [0, 0, 10000] }))
+  const [ref, api] = useSphere(() => ({ type: 'Static', args: [0.5], position: [0, 0, 10000] }), cursor)
   useFrame((e) => {
     eyes.current.position.y = Math.sin(e.clock.getElapsedTime() * 1) * 0.06
     mouth.current.scale.y = (1 + Math.sin(e.clock.getElapsedTime())) * 1.5


### PR DESCRIPTION
https://github.com/react-spring/use-cannon/issues/53

i would propose to remove dependencies in favour of an optional ref argument. 

currently there's a new regression where refs aren't accessible any longer:

```jsx
// this will crash
const [ref] = useConvexPolyhedron(() => ({ args: ref.current.geometry })) 
```

it happens because the body-fn is called as a side effect, which isn't good. previously it was only called in use[Layout]Effect, which guarantees that refs have been slotted.

```jsx
function useBody(type: BodyShapeType, fn: BodyFn, argFn: ArgFn, deps: any[] = []): Api {
  const { ref: fwdRef } = fn(0)
```

solution:

```jsx
// now: dependencies serve no real function atm
// why would we ever want to reset a hook, it can be done by the api
const [ref] = useXYZ(() => ({ ref: forwardRef, ... }), [uselessDependencies])

// proposal: local ref must be accessible, deps aren't needed
const [ref] = useXYZ(() => ({ ... }), forwardRef)
```

the code above will not crash any longer ...