### PR TITLE
Add subscriptions to Worker API

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import type { Object3D } from 'three'
 import type { WorkerCollideEvent, WorkerRayhitEvent } from './Provider'
+import type { AtomicProps } from './hooks'
 import React, { Suspense, createContext, lazy } from 'react'
 import { ProviderProps } from './Provider'
 export * from './hooks'
@@ -10,6 +11,9 @@ export type Event =
   | (Omit<WorkerRayhitEvent['data'], 'body'> & { body: Object3D | null })
   | (Omit<WorkerCollideEvent['data'], 'body' | 'target'> & { body: Object3D; target: Object3D })
 export type Events = { [uuid: string]: (e: Event) => void }
+export type Subscriptions = {
+  [uuid: string]: { [key: string]: (value: AtomicProps[keyof AtomicProps] | number[]) => void }
+}
 
 export type ProviderContext = {
   worker: Worker
@@ -17,6 +21,7 @@ export type ProviderContext = {
   buffers: Buffers
   refs: Refs
   events: Events
+  subscriptions: Subscriptions
 }
 
 const context = createContext<ProviderContext>({} as ProviderContext)

--- a/src/worker.js
+++ b/src/worker.js
@@ -30,6 +30,7 @@ const springs = {}
 const rays = {}
 const world = new World()
 const config = { step: 1 / 60 }
+const subscriptions = {}
 
 function createShape(type, args) {
   switch (type) {
@@ -90,7 +91,8 @@ self.onmessage = (e) => {
     }
     case 'step': {
       world.step(config.step)
-      for (let i = 0; i < world.bodies.length; i++) {
+      const numberOfBodies = world.bodies.length
+      for (let i = 0; i < numberOfBodies; i++) {
         let b = world.bodies[i],
           p = b.position,
           q = b.quaternion
@@ -111,6 +113,18 @@ self.onmessage = (e) => {
         },
         [positions.buffer, quaternions.buffer]
       )
+      for (const uuid of Object.keys(subscriptions)) {
+        for (const type of subscriptions[uuid]) {
+          let value = bodies[uuid][type]
+          if (value instanceof Vec3) value = value.toArray()
+          else if (value instanceof Quaternion) {
+            const euler = new Vec3()
+            value.toEuler(euler)
+            value = euler.toArray()
+          }
+          self.postMessage({ op: 'observe', uuid, type, value })
+        }
+      }
       break
     }
     case 'addBodies': {
@@ -185,10 +199,24 @@ self.onmessage = (e) => {
       syncBodies()
       break
     }
+    case 'subscribe':
+      if (subscriptions[uuid] && !subscriptions[uuid].includes(props)) subscriptions[uuid].push(props)
+      else subscriptions[uuid] = [props]
+      break
+    case 'unsubscribe':
+      if (!subscriptions[uuid]) return
+      const index = subscriptions[uuid].indexOf(props)
+      if (index !== -1) {
+        subscriptions[uuid] = subscriptions[uuid].splice(index, 1)
+      }
+      if (subscriptions[uuid].length === 0) {
+        delete subscriptions[uuid]
+      }
+      break
     case 'setPosition':
       bodies[uuid].position.set(props[0], props[1], props[2])
       break
-    case 'setRotation':
+    case 'setQuaternion':
       bodies[uuid].quaternion.setFromEuler(props[0], props[1], props[2], 'XYZ')
       break
     case 'setVelocity':


### PR DESCRIPTION
Addresses #45.

I think this could be improved by switching to `const subscriptions = new Map()` in the worker, but we should probably talk about the implications first (polyfills for old browsers).

I tested subscribing and unsubscribing to velocity, position, rotation, mass, and allowSleep. I figured that was enough to know they're mostly working 🤷‍♂ 

It also needs to be more strictly typed, but I wanted to get this out there 👋👋👋 